### PR TITLE
Audio click fix

### DIFF
--- a/Source/SynthVoice.cpp
+++ b/Source/SynthVoice.cpp
@@ -25,7 +25,7 @@ void SynthVoice::stopNote(float velocity, bool allowTailOff)
 {
     adsr.noteOff();
 
-    if (!allowTailOff || !adsr.isActive())
+    if (! allowTailOff || ! adsr.isActive())
     {
         clearCurrentNote();
     }
@@ -56,18 +56,20 @@ void SynthVoice::renderNextBlock(juce::AudioBuffer< float >& outputBuffer, int s
         return;
     }
     //the set size and addfrom in this function make the plugin functionally monophonic
-    synthBuffer.setSize(1, numSamples, false, false, true);
+    synthBuffer.setSize(outputBuffer.getNumChannels(), numSamples, false, false, true);
+
+
     synthBuffer.clear();
 
     osc.processBlock(synthBuffer);
-    adsr.applyEnvelopeToBuffer(synthBuffer, startSample, numSamples);
-    synthBuffer.applyGain(startSample, numSamples, .2f);
+    adsr.applyEnvelopeToBuffer(synthBuffer, 0, synthBuffer.getNumSamples());
+    synthBuffer.applyGain(0, synthBuffer.getNumSamples(), .2f);
 
     for (int channel = 0; channel < outputBuffer.getNumChannels(); ++channel)
     {
-        outputBuffer.addFrom(channel, startSample, synthBuffer, 1, 0, numSamples);
+        outputBuffer.addFrom(channel, startSample, synthBuffer, channel, 0 , numSamples);
 
-        if (!adsr.isActive())
+        if (! adsr.isActive())
         {
             clearCurrentNote();
         }

--- a/Source/SynthVoice.h
+++ b/Source/SynthVoice.h
@@ -28,6 +28,7 @@ public:
 private:
 	juce::ADSR adsr;
 	juce::ADSR::Parameters adsrParameters;
+	juce::AudioBuffer<float> synthBuffer;
 
 	Oscillator osc;
 


### PR DESCRIPTION
This solves the audio clicks on note on/off/change. Was caused by a discrepency between a start sample of the audiobuffer and the synth engine/key on. by having a dedicated buffer to the synth voice that fills and adds to the output buffer, the clicks are gone.

While the synth buffer should be set up in preparetoplay of the synthvoice, currently cant get that to work without introducing new clicks on note off, and also this fixes a major bug and is being pulled ASAP with maybe a new ticket or branch being made to address it.