### PR TITLE
Glide fix for filter

### DIFF
--- a/Source/DSP/SVFFilter.h
+++ b/Source/DSP/SVFFilter.h
@@ -38,7 +38,6 @@ private:
     float cutoffCoeff;
     float damping; //oscillates at 0, do not allow to become 0 unless clipping is implemented
     float dampingCoeff;
-    float keyboardTracking;
     float sampleRate;
     float sampleTime;
     float avg1;

--- a/Source/Oscillator.cpp
+++ b/Source/Oscillator.cpp
@@ -20,27 +20,27 @@ void Oscillator::updateSamplerate(float sampleRate)
 {
     Oscillator::sampleRate = sampleRate;
     updateDelta();
-    filter.updateSampleRate(sampleRate);
+    //filter.updateSampleRate(sampleRate);
 }
 
-void Oscillator::updateGlide(float glide)
-{
-    filter.updateCutoff(glide);
-}
+//void Oscillator::updateGlide(float glide)
+//{
+//    filter.updateCutoff(glide);
+//}
 
 void Oscillator::reset()
 {
     deltaPhase = 0;
     currentPhase = 0;
     subWave = 1.0f;
-    updateGlide(1.0f);
+    //updateGlide(1.0f);
 }
 
 
 float Oscillator::processSample()
 {
-    float currentFreq = filter.advanceFilter(frequency);
-    updateDelta(currentFreq);
+    //float currentFreq = filter.advanceFilter(frequency);
+    updateDelta(frequency);
 
     currentPhase += deltaPhase;
     float sawWave = 2.0f * currentPhase - 1.0f;

--- a/Source/Oscillator.cpp
+++ b/Source/Oscillator.cpp
@@ -20,26 +20,18 @@ void Oscillator::updateSamplerate(float sampleRate)
 {
     Oscillator::sampleRate = sampleRate;
     updateDelta();
-    //filter.updateSampleRate(sampleRate);
 }
-
-//void Oscillator::updateGlide(float glide)
-//{
-//    filter.updateCutoff(glide);
-//}
 
 void Oscillator::reset()
 {
     deltaPhase = 0;
     currentPhase = 0;
     subWave = 1.0f;
-    //updateGlide(1.0f);
 }
 
 
 float Oscillator::processSample()
 {
-    //float currentFreq = filter.advanceFilter(frequency);
     updateDelta(frequency);
 
     currentPhase += deltaPhase;

--- a/Source/Oscillator.h
+++ b/Source/Oscillator.h
@@ -10,10 +10,6 @@
 
 #pragma once
 #include <JuceHeader.h>
-//#include "DSP/filter.h"
-//so far, don't need these but keeping for now as they could become necessary at any time
-//#define USE_MATH_DEFINES //annoyingly necessary for microsoft
-//#include <math.h>
 
 class Oscillator {
 public:
@@ -39,6 +35,4 @@ private:
     float subGain;
     void updateDelta() { deltaPhase = frequency / sampleRate; }
     void updateDelta(float frequency) { deltaPhase = frequency / sampleRate; }
-
-    //filter filter;
 };

--- a/Source/Oscillator.h
+++ b/Source/Oscillator.h
@@ -10,7 +10,7 @@
 
 #pragma once
 #include <JuceHeader.h>
-#include "DSP/filter.h"
+//#include "DSP/filter.h"
 //so far, don't need these but keeping for now as they could become necessary at any time
 //#define USE_MATH_DEFINES //annoyingly necessary for microsoft
 //#include <math.h>
@@ -20,7 +20,7 @@ public:
 
     void updateFrequency(float frequency);
     void updateSamplerate(float sampleRate);
-    void updateGlide(float glide);
+    //void updateGlide(float glide);
     void reset();
     float processSample();
     float fundamental(float phase);
@@ -40,5 +40,5 @@ private:
     void updateDelta() { deltaPhase = frequency / sampleRate; }
     void updateDelta(float frequency) { deltaPhase = frequency / sampleRate; }
 
-    filter filter;
+    //filter filter;
 };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -248,7 +248,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout BasssynthAudioProcessor::cre
     //filter controls
     params.push_back(std::make_unique<juce::AudioParameterFloat>("KEYBOARDTRACKING", "Filter Keyboard Tracking", juce::NormalisableRange<float> { 0.0f, 1.0f, 0.01f, 1.0f }, 0.5f));
     params.push_back(std::make_unique<juce::AudioParameterFloat>("CUTOFF", "Cutoff Frequency", juce::NormalisableRange<float> { 0.0f, 22000.0f, 1.0f, 0.3f }, 10000.0f));
-    params.push_back(std::make_unique<juce::AudioParameterFloat>("RESONANCE", "Filter Resonance", juce::NormalisableRange<float> { 0.5f, 0.99f, 0.001f, 1.5f }, 0.707f));
+    params.push_back(std::make_unique<juce::AudioParameterFloat>("RESONANCE", "Filter Resonance", juce::NormalisableRange<float> { 0.0f, 0.99f, 0.001f, 2.0f }, 0.707f));
 
     //adsr controls
     params.push_back(std::make_unique<juce::AudioParameterFloat>("ATTACK", "Attack", juce::NormalisableRange<float> { 0.0f, 1.0f, 0.001f, 0.5f }, 0.01f));

--- a/Source/SynthVoice.cpp
+++ b/Source/SynthVoice.cpp
@@ -70,7 +70,7 @@ void SynthVoice::update(const float glide, const float fundType, const float fun
     svfFilter.updateResonance(resonance);
     osc.updateControls(fundType, fundGain, sawGain, subGain);
     osc.updateFrequency(currentFrequency);
-    osc.updateGlide(glide);
+    //osc.updateGlide(glide);
 }
 
 void SynthVoice::renderNextBlock(juce::AudioBuffer< float >& outputBuffer, int startSample, int numSamples)

--- a/Source/SynthVoice.h
+++ b/Source/SynthVoice.h
@@ -14,6 +14,7 @@
 #include "SynthSound.h"
 #include "Oscillator.h"
 #include "ADSRdata.h"
+#include"DSP/filter.h"
 #include "DSP/SVFFilter.h"
 #include <math.h>
 
@@ -31,15 +32,18 @@ public:
 	 
 private:
 	float calculatePitchbend(int pitchwheelPosition);
-	void updateTrackingRatio(int midiNoteNumber, int currentPitchWheelPosition);
+	void updateTrackingRatio();
 
 	float gain;
 	float keyboardTracking;
+    float targetFrequency;
+    float currentFrequency;
 	float trackingRatio;
 	float cutoff;
 	adsrData adsr;
 	juce::AudioBuffer<float> synthBuffer;
 	SVFFilter svfFilter;
 	Oscillator osc;
+    filter glideFilter;
 
 }; 

--- a/Source/SynthVoice.h
+++ b/Source/SynthVoice.h
@@ -31,13 +31,14 @@ public:
 	void renderNextBlock(juce::AudioBuffer< float >& outputBuffer, int startSample, int numSamples) override;
 	 
 private:
-	float calculatePitchbend(int pitchwheelPosition);
+	void updatePitchbend(int pitchwheelPosition);
 	void updateTrackingRatio();
 
 	float gain;
 	float keyboardTracking;
     float targetFrequency;
     float currentFrequency;
+    float pitchbendRatio;
 	float trackingRatio;
 	float cutoff;
 	adsrData adsr;


### PR DESCRIPTION
Glide updates every block; at larger blocks this has audible stepping. Leaving the glide functionality inside of the oscillator and frequency class feels like bad programming but unsure how to effectively update per sample when SynthVoice operates on the block as a whole.

Fixed a small error in response in the keyboard tracking function
Updated the range and taper of Resonance control
Deleted glide functionality out of oscillator class
Changed updateTrackingRatio to have frequencies as input instead of Midi Note, which is much cleaner and easier actually.