### PR TITLE
Saturation edge-case cleanup

### DIFF
--- a/Source/saturation.cpp
+++ b/Source/saturation.cpp
@@ -24,7 +24,7 @@ void Saturation::processSample(float& sample, int channel)
     
     //if statement avoids divide by zero if the last sample is too close to the current
     //the lesser than amount was chosen arbitrarily but works well so far.
-    if (sampleDifference < 0.00000001f)
+    if (fabs(sampleDifference) < 0.0001f)
     {
         output = clip((sample + lastSample[channel]) / 2.0f);
     } else {


### PR DESCRIPTION
Saturation divide-by-zero case was guessed, and guessed poorly. By altering the precision, the clicks from audio are gone, and further tests were done to get the noise floor as low as possible. Further work may need to be done, but it's already below 96dBFS.