### PR TITLE
Mixer controls now give visual feedback of clipping

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -220,7 +220,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout BasssynthAudioProcessor::cre
 
     //filter controls
     params.push_back(std::make_unique<juce::AudioParameterFloat>("KEYBOARDTRACKING", "Filter Keyboard Tracking", juce::NormalisableRange<float> { 0.0f, 1.0f, 0.01f, 1.0f }, 0.5f));
-    params.push_back(std::make_unique<juce::AudioParameterFloat>("CUTOFF", "Cutoff Frequency", juce::NormalisableRange<float> { 0.0f, 22000.0f, 1.0f, 0.3f }, 10000.0f));
+    params.push_back(std::make_unique<juce::AudioParameterFloat>("CUTOFF", "Cutoff Frequency", juce::NormalisableRange<float> { 20.0f, 22000.0f, 1.0f, 0.3f }, 10000.0f));
     params.push_back(std::make_unique<juce::AudioParameterFloat>("RESONANCE", "Filter Resonance", juce::NormalisableRange<float> { 0.0f, 0.99f, 0.001f, 2.0f }, 0.5f));
 
     //adsr controls

--- a/Source/UI/OscComponent.cpp
+++ b/Source/UI/OscComponent.cpp
@@ -24,6 +24,11 @@ OscComponent::OscComponent(juce::AudioProcessorValueTreeState& apvts)
     setSliderParams(fundGainSlider);
     setSliderParams(sawGainSlider);
     setSliderParams(subGainSlider);
+
+    fundGainSlider.onValueChange = [this] {updateThumb(fundGainSlider); };
+    sawGainSlider.onValueChange = [this] {updateThumb(sawGainSlider); };
+    subGainSlider.onValueChange = [this] {updateThumb(subGainSlider); };
+
     glideSlider.setColour(juce::Slider::thumbColourId, juce::Colours::dimgrey);
 
     addAndMakeVisible(waveshapeButton);
@@ -60,7 +65,14 @@ void OscComponent::setSliderParams(juce::Slider& slider)
 {
     slider.setSliderStyle(juce::Slider::SliderStyle::LinearVertical);
     slider.setTextBoxStyle(juce::Slider::TextBoxBelow, true, 50, 25);
-    slider.setColour(juce::Slider::thumbColourId, juce::Colours::mediumseagreen);
+    updateThumb(slider);
 
     addAndMakeVisible(slider);
+}
+
+void OscComponent::updateThumb(juce::Slider& slider)
+{
+    auto lowColour = juce::Colours::mediumseagreen;
+    auto highColour = juce::Colours::orange;
+    slider.setColour(juce::Slider::thumbColourId, lowColour.interpolatedWith(highColour, slider.getValue() / 2.0f));
 }

--- a/Source/UI/OscComponent.h
+++ b/Source/UI/OscComponent.h
@@ -26,6 +26,7 @@ public:
 
 private:
     void setSliderParams(juce::Slider& slider);
+    void updateThumb(juce::Slider& slider);
 
     juce::Slider glideSlider;
     juce::Slider fundGainSlider;

--- a/Source/saturation.cpp
+++ b/Source/saturation.cpp
@@ -23,7 +23,7 @@ void Saturation::processSample(float& sample, int channel)
     float output = 0.0f;
     
     //if statement avoids divide by zero if the last sample is too close to the current
-    //the lesser than amount was chosen arbitrarily but works well so far.
+    //the lesser than amount was chosen after some guess and check for the smallest number that maintains good SNR.
     if (fabs(sampleDifference) < 0.0001f)
     {
         output = clip((sample + lastSample[channel]) / 2.0f);


### PR DESCRIPTION
Middle colour is a little gross and could be overall refined across all of the colors and taper, but as proof of concept i think i really like it. final product would have the vibe of a VU meter; user should have some idea of clipping and the red indicator should not be at all scary.